### PR TITLE
Safer comparisons with nothing

### DIFF
--- a/src/instance.jl
+++ b/src/instance.jl
@@ -138,13 +138,13 @@ function from_json(json; fix=true)
     name_to_unit = Dict{String, Unit}()
     
     function timeseries(x; default=nothing)
-        x != nothing || return default
+        x !== nothing || return default
         x isa Array || return [x for t in 1:T]
         return x
     end
     
     function scalar(x; default=nothing)
-        x != nothing || return default
+        x !== nothing || return default
         x
     end
     
@@ -194,10 +194,10 @@ function from_json(json; fix=true)
         # Read and validate initial conditions
         initial_power = scalar(dict["Initial power (MW)"], default=nothing)
         initial_status = scalar(dict["Initial status (h)"], default=nothing)
-        if initial_power == nothing
-            initial_status == nothing || error("unit $unit_name has initial status but no initial power")
+        if initial_power === nothing
+            initial_status === nothing || error("unit $unit_name has initial status but no initial power")
         else
-            initial_status != nothing || error("unit $unit_name has initial power but no initial status")
+            initial_status !== nothing || error("unit $unit_name has initial power but no initial status")
             initial_status != 0 || error("unit $unit_name has invalid initial status")
             if initial_status < 0 && initial_power > 1e-3
                 error("unit $unit_name has invalid initial power")

--- a/src/log.jl
+++ b/src/log.jl
@@ -39,7 +39,7 @@ function handle_message(logger::TimeLogger,
         print(time_string)
         println(message)
     end
-    if logger.file != nothing && level >= logger.io_log_level
+    if logger.file !== nothing && level >= logger.io_log_level
         write(logger.file, time_string)
         write(logger.file, message)
         write(logger.file, "\n")

--- a/src/model.jl
+++ b/src/model.jl
@@ -45,11 +45,11 @@ function build_model(;
                      variable_names::Bool=false,
                     ) :: UnitCommitmentModel
 
-    if (filename == nothing) && (instance == nothing)
+    if (filename === nothing) && (instance === nothing)
         error("Either filename or instance must be specified")
     end
     
-    if filename != nothing
+    if filename !== nothing
         @info "Reading: $(filename)"
         time_read = @elapsed begin
             instance = UnitCommitment.read(filename)
@@ -61,7 +61,7 @@ function build_model(;
         isf = zeros(0, 0)
         lodf = zeros(0, 0)
     else
-        if isf == nothing
+        if isf === nothing
             @info "Computing injection shift factors..."
             time_isf = @elapsed begin
                 isf = UnitCommitment.injection_shift_factors(lines=instance.lines,
@@ -85,8 +85,8 @@ function build_model(;
 
     @info "Building model..."
     time_model = @elapsed begin
-        if model == nothing
-            if optimizer == nothing
+        if model === nothing
+            if optimizer === nothing
                 mip = Model()
             else
                 mip = Model(optimizer)
@@ -193,7 +193,7 @@ function add_unit!(model::UnitCommitmentModel, g::Unit)
         error("Partially must-run units are not currently supported")
     end
     
-    if g.initial_power == nothing || g.initial_status == nothing
+    if g.initial_power === nothing || g.initial_status === nothing
         error("Initial conditions for $(g.name) must be provided")
     end
 
@@ -416,7 +416,7 @@ function enforce_transmission(;
     instance, mip, vars = model.instance, model.mip, model.vars
     limit::Float64 = 0.0
         
-    if violation.outage_line == nothing
+    if violation.outage_line === nothing
         limit = violation.monitored_line.normal_flow_limit[violation.time]
         @info @sprintf("    %8.3f MW overflow in %-5s time %3d (pre-contingency)",
                        violation.amount,
@@ -439,7 +439,7 @@ function enforce_transmission(;
     @constraint(mip, flow  <= limit + overflow)
     @constraint(mip, -flow <= limit + overflow)
     
-    if violation.outage_line == nothing
+    if violation.outage_line === nothing
         @constraint(mip, flow == sum(vars.net_injection[b.name, violation.time] *
                                          isf[violation.monitored_line.offset, b.offset]
                                      for b in instance.buses

--- a/test/initcond_test.jl
+++ b/test/initcond_test.jl
@@ -11,8 +11,8 @@ using UnitCommitment, Cbc, JuMP
     
     # All units should have unknown initial conditions
     for g in instance.units
-        @test g.initial_power == nothing
-        @test g.initial_status == nothing
+        @test g.initial_power === nothing
+        @test g.initial_status === nothing
     end
     
     # Generate initial conditions
@@ -20,8 +20,8 @@ using UnitCommitment, Cbc, JuMP
     
     # All units should now have known initial conditions
     for g in instance.units
-        @test g.initial_power != nothing
-        @test g.initial_status != nothing
+        @test g.initial_power !== nothing
+        @test g.initial_status !== nothing
     end
     
     # TODO: Check that initial conditions are feasible


### PR DESCRIPTION
The recommended syntax for comparing whether `x` is `nothing` is
```julia
x === nothing
x !== nothing
```

It is more compiler-friendly than `x == nothing` and `x != nothing`, which can technically be overloaded by a user.