### PR TITLE
Package dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ repo = "https://github.com/ANL-CEEESA/UnitCommitment.jl"
 version = "0.1.0"
 
 [deps]
-Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -16,7 +15,6 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Cbc = "0.7"
@@ -27,3 +25,10 @@ JuMP = "0.21"
 MathOptInterface = "0.9"
 PackageCompiler = "1"
 julia = "1"
+
+[extras]
+Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Cbc", "Test"]


### PR DESCRIPTION
The `Cbc` and `Test` packages are only used for testing.
The guidelines for test-specific dependencies for [Julia 1.0-1.1](https://julialang.github.io/Pkg.jl/v1/creating-packages/#Test-specific-dependencies-in-Julia-1.0-and-1.1) and [Julia 1.2+](https://julialang.github.io/Pkg.jl/v1/creating-packages/#Test-specific-dependencies-in-Julia-1.2-and-above).

Finally, the `Manifest.toml` is typically _not_ checked out in Julia packages (although, AFAIK the official guidelines are not 100% clear).
The main benefit of having it seems to be that package developers can then work with the same environment. However, the Manifest.toml must be updated manually (and committed) every time one wants to use a more recent version of any dependency (including transient ones).