### PR TITLE
Precompile statements for sysimage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ VERSION := 0.1
 
 build/sysimage.so: src/sysimage.jl Project.toml Manifest.toml
 	mkdir -p build
+	$(JULIA) --trace-compile=precompile.jl benchmark/run.jl test/case14.json.gz
 	$(JULIA) src/sysimage.jl
+	rm precompile.jl
 
 clean:
 	rm -rf build/*

--- a/src/sysimage.jl
+++ b/src/sysimage.jl
@@ -18,4 +18,4 @@ pkg = [:DataStructures,
        ]
 
 @info "Building system image..."
-create_sysimage(pkg, sysimage_path="build/sysimage.so")
+create_sysimage(pkg, precompile_statements_file=joinpath(@__DIR__, "../precompile.jl"), sysimage_path="build/sysimage.so")


### PR DESCRIPTION
This PR adds a list of precompile statements for generating the sysimage (see the [PackageCompiler docs](https://julialang.github.io/PackageCompiler.jl/dev/sysimages/#tracing-1) for background).

The logs below show that, in the current form, there's virtually no gain to using a sysimage. That's because everything still needs to be compiled at runtime.
When the sysimage is built with precompile statements, runtimes are improved significantly.

The precompile statements are generated by running the `test/case14` example.
Basically, all functions that are compiled while running this test case will be included in the sysimage.
It's hard to be exhaustive, but I guess this should cover most typical cases.

___

Log with no sysimage:
```
[       0.024] Reading: test/case14
[       2.825] Read problem in 2.80 seconds
[       3.404] Computed ISF in 0.57 seconds
[       3.883] Computed LODF in 0.48 seconds
[       6.958] Built model in 2.95 seconds
[       6.958] Optimizing...
[      16.342] Total time was 16.34 seconds
[      18.152] Set names in 0.43 seconds
```

Log with sysimage, before:
```
[       0.024] Reading: test/case14
[       3.092] Read problem in 3.07 seconds
[       3.676] Computed ISF in 0.57 seconds
[       4.175] Computed LODF in 0.50 seconds
[       7.426] Built model in 3.12 seconds
[       7.426] Optimizing...
[      16.522] Total time was 16.52 seconds
[      18.273] Set names in 0.42 seconds
```

Log with sysimage, after:
```
[       0.024] Reading: test/case14
[       1.859] Read problem in 1.83 seconds
[       2.405] Computed ISF in 0.55 seconds
[       2.867] Computed LODF in 0.46 seconds
[       3.505] Built model in 0.63 seconds
[       3.505] Optimizing...
[       7.055] Total time was 7.05 seconds
[       8.087] Set names in 0.01 seconds
```