### PR TITLE
Fix make test pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ install-deps-docs:
 
 test: build/sysimage.so
 	@echo Running tests...
-	cd test; $(JULIA) --sysimage ../build/sysimage.so runtests.jl | tee ../build/test.log
+	$(JULIA) --sysimage build/sysimage.so -e 'using Pkg; Pkg.test("UnitCommitment")' | tee build/test.log
 
 .PHONY: docs docs-push build test


### PR DESCRIPTION
The current `make test` runs the following command (I'm omitting the sysimage for brevity)
```julia
julia --project=@. test/runtests.jl
```
This pipeline was broken by #2, which made `Cbc` and `Test` test-only dependencies.
If you run `make test` on the current `dev` branch, you will get an error `Cbc not installed`.

This PR fixes that, and uses the same pipeline for `make test` as that used in CI:
```julia
julia --project=@. -e 'using Pkg; Pkg.test("UnitCommitment")'
```
Running tests via Julia's `Pkg` ensures that all test-only dependencies are properly installed.