### PR TITLE
Fix Array type instability

### DIFF
--- a/src/instance.jl
+++ b/src/instance.jl
@@ -12,15 +12,15 @@ import GZip
 mutable struct Bus
     name::String
     offset::Int
-    load::Array{Float64}
+    load::Vector{Float64}
     units::Array
     price_sensitive_loads::Array
 end
 
 
 mutable struct CostSegment
-    mw::Array{Float64}
-    cost::Array{Float64}
+    mw::Vector{Float64}
+    cost::Vector{Float64}
 end
 
 
@@ -33,11 +33,11 @@ end
 mutable struct Unit
     name::String
     bus::Bus
-    max_power::Array{Float64}
-    min_power::Array{Float64}
-    must_run::Array{Bool}
-    min_power_cost::Array{Float64}
-    cost_segments::Array{CostSegment}
+    max_power::Vector{Float64}
+    min_power::Vector{Float64}
+    must_run::Vector{Bool}
+    min_power_cost::Vector{Float64}
+    cost_segments::Vector{CostSegment}
     min_uptime::Int
     min_downtime::Int
     ramp_up_limit::Float64
@@ -46,8 +46,8 @@ mutable struct Unit
     shutdown_limit::Float64
     initial_status::Union{Int,Nothing}
     initial_power::Union{Float64,Nothing}
-    provides_spinning_reserves::Array{Bool}
-    startup_categories::Array{StartupCategory}
+    provides_spinning_reserves::Vector{Bool}
+    startup_categories::Vector{StartupCategory}
 end
 
 
@@ -58,41 +58,41 @@ mutable struct TransmissionLine
     target::Bus
     reactance::Float64
     susceptance::Float64
-    normal_flow_limit::Array{Float64}
-    emergency_flow_limit::Array{Float64}
-    flow_limit_penalty::Array{Float64}
+    normal_flow_limit::Vector{Float64}
+    emergency_flow_limit::Vector{Float64}
+    flow_limit_penalty::Vector{Float64}
 end
 
 
 mutable struct Reserves
-    spinning::Array{Float64}
+    spinning::Vector{Float64}
 end
 
 
 mutable struct Contingency
     name::String
-    lines::Array{TransmissionLine}
-    units::Array{Unit}
+    lines::Vector{TransmissionLine}
+    units::Vector{Unit}
 end
 
 
 mutable struct PriceSensitiveLoad
     name::String
     bus::Bus
-    demand::Array{Float64}
-    revenue::Array{Float64}
+    demand::Vector{Float64}
+    revenue::Vector{Float64}
 end
 
 
 mutable struct UnitCommitmentInstance
     time::Int
-    power_balance_penalty::Array{Float64}
-    units::Array{Unit}
-    buses::Array{Bus}
-    lines::Array{TransmissionLine}
+    power_balance_penalty::Vector{Float64}
+    units::Vector{Unit}
+    buses::Vector{Bus}
+    lines::Vector{TransmissionLine}
     reserves::Reserves
-    contingencies::Array{Contingency}
-    price_sensitive_loads::Array{PriceSensitiveLoad}
+    contingencies::Vector{Contingency}
+    price_sensitive_loads::Vector{PriceSensitiveLoad}
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -27,8 +27,8 @@ mutable struct UnitCommitmentModel
     eqs::DotDict
     exprs::DotDict
     instance::UnitCommitmentInstance
-    isf::Array{Float64, 2}
-    lodf::Array{Float64, 2}
+    isf::Matrix{Float64}
+    lodf::Matrix{Float64}
     obj::AffExpr
 end
 
@@ -410,9 +410,9 @@ end
 function enforce_transmission(;
                               model::UnitCommitmentModel,
                               violation::Violation,
-                              isf::Array{Float64,2},
-                              lodf::Array{Float64,2})::Nothing
-    
+                              isf::Matrix{Float64},
+                              lodf::Matrix{Float64})::Nothing
+
     instance, mip, vars = model.instance, model.mip, model.vars
     limit::Float64 = 0.0
         


### PR DESCRIPTION
Adresses #9.

I changed occurrences of `::Array{Something}` to `::Vector{Something}` in internal data structures' definitions.
Someone may want to check that I did not put a `Vector` where there should have been a `Matrix`; all unit tests pass locally though.

There is still `units::Array` and `price_sensitive_loads::Array` in the definition of `Bus`. I tried to changed these to `Vector{Unit}` and `Vector{PriceSensitiveLoad}`, but it errors at compilation because those types haven't been defined yet.
I don't believe forward declaration of types is possible in Julia at the moment.

___

Here's an example illustrating the effects of the proposed modification.
The function below simply extracts the minimum power cost for each generator and each time period. On the current `dev`, this allocates ~170kB of memory. On the revised branch, the same code allocates 0kB and runs a 100x faster.

```julia
using BenchmarkTools
using LinearAlgebra
BLAS.set_num_threads(1)

using UnitCommitment

instance = UnitCommitment.read_benchmark("matpower/case1354pegase/2017-02-01")

function get_min_power_cost!(Z, uc::UnitCommitmentInstance)
    T = uc.time
    G = length(uc.units)
    for (g, gen) in enumerate(uc.units)
        for t in 1:T
            Z[g, t] = gen.min_power_cost[t]
        end
    end
    return Z
end

T = instance.time
G = length(instance.units)
Z = zeros(G, T)

println("UC instance has $G units and $T time periods")

println("Extracting min_power_cost matrix")
b = @benchmark get_min_power_cost!($Z, $instance)
display(b)
println()
```

Before:
```
UC instance has 260 units and 36 time periods
Extracting min_power_cost matrix
BenchmarkTools.Trial: 
  memory estimate:  174.70 KiB
  allocs estimate:  10141
  --------------
  minimum time:     796.400 μs (0.00% GC)
  median time:      889.650 μs (0.00% GC)
  mean time:        920.316 μs (0.96% GC)
  maximum time:     3.437 ms (73.81% GC)
  --------------
  samples:          5426
  evals/sample:     1
```
With the changes:
```
UC instance has 260 units and 36 time periods
Extracting min_power_cost matrix
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     8.967 μs (0.00% GC)
  median time:      9.167 μs (0.00% GC)
  mean time:        9.313 μs (0.00% GC)
  maximum time:     60.567 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     3
```

